### PR TITLE
remove GetRoot from consensus state interface; cast to tendermint to …

### DIFF
--- a/modules/core/exported/client.go
+++ b/modules/core/exported/client.go
@@ -135,10 +135,6 @@ type ConsensusState interface {
 
 	ClientType() string // Consensus kind
 
-	// GetRoot returns the commitment root of the consensus state,
-	// which is used for key-value pair verification.
-	GetRoot() Root
-
 	// GetTimestamp returns the timestamp (in nanoseconds) of the consensus state
 	GetTimestamp() uint64
 


### PR DESCRIPTION
…avoid breaking backwards compatibility
