### PR TITLE
return proof height from multi-hop proof query

### DIFF
--- a/modules/core/04-channel/keeper/multihop_handshake_test.go
+++ b/modules/core/04-channel/keeper/multihop_handshake_test.go
@@ -261,13 +261,15 @@ func (suite *MultihopTestSuite) TestChanOpenTryMultihop() {
 				suite.Require().NoError(err)
 			}
 
-			proof, err := suite.A().QueryChannelProof(suite.A().Chain.LastHeader.GetHeight())
+			proof, proofHeight, err := suite.A().QueryChannelProof(suite.A().Chain.LastHeader.GetHeight())
 
 			if tc.expPass {
 				suite.Require().NoError(err)
 			} else if err != nil {
 				return
 			}
+
+			fmt.Printf("proofHeight=%v client proofHeight=%v\n", proofHeight, suite.Z().ProofHeight())
 
 			channelID, capability, err := suite.Z().Chain.App.GetIBCKeeper().ChannelKeeper.ChanOpenTry(
 				suite.Z().Chain.GetContext(),
@@ -278,7 +280,7 @@ func (suite *MultihopTestSuite) TestChanOpenTryMultihop() {
 				suite.Z().CounterpartyChannel(),
 				suite.A().ChannelConfig.Version,
 				proof,
-				malleateHeight(suite.Z().ProofHeight(), heightDiff),
+				malleateHeight(proofHeight, heightDiff),
 			)
 
 			if tc.expPass {
@@ -446,7 +448,7 @@ func (suite *MultihopTestSuite) TestChanOpenAckMultihop() {
 				counterpartyChannelID = ibctesting.FirstChannelID
 			}
 
-			proof, err := suite.Z().QueryChannelProof(suite.Z().Chain.LastHeader.GetHeight())
+			proof, proofHeight, err := suite.Z().QueryChannelProof(suite.Z().Chain.LastHeader.GetHeight())
 
 			if tc.expPass {
 				suite.Require().NoError(err)
@@ -462,7 +464,7 @@ func (suite *MultihopTestSuite) TestChanOpenAckMultihop() {
 				suite.Z().ChannelConfig.Version,
 				counterpartyChannelID,
 				proof,
-				malleateHeight(suite.A().ProofHeight(), heightDiff),
+				malleateHeight(proofHeight, heightDiff),
 			)
 
 			if tc.expPass {
@@ -593,7 +595,7 @@ func (suite *MultihopTestSuite) TestChanOpenConfirmMultihop() {
 			heightDiff = 0    // must be explicitly changed
 			tc.malleate()     // call ChanOpenInit and setup port capabilities
 
-			proof, err := suite.A().QueryChannelProof(suite.A().Chain.LastHeader.GetHeight())
+			proof, proofHeight, err := suite.A().QueryChannelProof(suite.A().Chain.LastHeader.GetHeight())
 
 			if tc.expPass {
 				suite.Require().NoError(err)
@@ -607,7 +609,7 @@ func (suite *MultihopTestSuite) TestChanOpenConfirmMultihop() {
 				suite.Z().ChannelID,
 				channelCap,
 				proof,
-				malleateHeight(suite.Z().ProofHeight(), heightDiff),
+				malleateHeight(proofHeight, heightDiff),
 			)
 
 			if tc.expPass {
@@ -678,7 +680,7 @@ func (suite *MultihopTestSuite) TestChanCloseConfirmMultihop() {
 
 			tc.malleate()
 
-			proof, err := suite.A().QueryChannelProof(suite.A().Chain.LastHeader.GetHeight())
+			proof, proofHeight, err := suite.A().QueryChannelProof(suite.A().Chain.LastHeader.GetHeight())
 
 			if tc.expPass {
 				suite.Require().NoError(err)
@@ -687,9 +689,11 @@ func (suite *MultihopTestSuite) TestChanCloseConfirmMultihop() {
 			}
 
 			err = suite.Z().Chain.App.GetIBCKeeper().ChannelKeeper.ChanCloseConfirm(
-				suite.Z().Chain.GetContext(), suite.Z().ChannelConfig.PortID, suite.Z().ChannelID,
+				suite.Z().Chain.GetContext(),
+				suite.Z().ChannelConfig.PortID,
+				suite.Z().ChannelID,
 				channelCap,
-				proof, suite.Z().ProofHeight(),
+				proof, proofHeight,
 			)
 
 			if tc.expPass {

--- a/modules/core/04-channel/keeper/multihop_packet_test.go
+++ b/modules/core/04-channel/keeper/multihop_packet_test.go
@@ -61,7 +61,7 @@ func (suite *MultihopTestSuite) TestRecvPacket() {
 
 			tc.malleate()
 
-			proof, err := suite.A().QueryPacketProof(packet, packetHeight)
+			proof, proofHeight, err := suite.A().QueryPacketProof(packet, packetHeight)
 			suite.Require().NoError(err)
 
 			err = suite.Z().Chain.App.GetIBCKeeper().ChannelKeeper.RecvPacket(
@@ -69,7 +69,7 @@ func (suite *MultihopTestSuite) TestRecvPacket() {
 				channelCap,
 				packet,
 				proof,
-				suite.Z().ProofHeight(),
+				proofHeight,
 			)
 
 			// assert no error
@@ -153,7 +153,7 @@ func (suite *MultihopTestSuite) TestAcknowledgePacket() {
 
 			tc.malleate()
 
-			proof, err := suite.Z().QueryPacketAcknowledgementProof(packet, packetHeight)
+			proof, proofHeight, err := suite.Z().QueryPacketAcknowledgementProof(packet, packetHeight)
 			suite.Require().NoError(err)
 
 			err = suite.A().Chain.App.GetIBCKeeper().ChannelKeeper.AcknowledgePacket(
@@ -162,7 +162,7 @@ func (suite *MultihopTestSuite) TestAcknowledgePacket() {
 				packet,
 				ack.Acknowledgement(),
 				proof,
-				suite.A().ProofHeight(),
+				proofHeight,
 			)
 
 			if tc.expPass {

--- a/modules/core/04-channel/keeper/multihop_timeout_test.go
+++ b/modules/core/04-channel/keeper/multihop_timeout_test.go
@@ -74,10 +74,8 @@ func (suite *MultihopTestSuite) TestTimeoutPacket() {
 					// proof of absence of packet receipt
 					key = host.PacketReceiptKey(packet.SourcePort, packet.SourceChannel, packet.Sequence)
 				}
-				proof, err = suite.Z().QueryMultihopProof(key, packetHeight)
+				proof, proofHeight, err = suite.Z().QueryMultihopProof(key, packetHeight)
 				suite.Require().NoError(err)
-
-				proofHeight = suite.A().ProofHeight()
 			}
 
 			err := suite.A().Chain.App.GetIBCKeeper().ChannelKeeper.TimeoutPacket(suite.A().Chain.GetContext(), packet, proof, proofHeight, nextSeqRecv)
@@ -141,10 +139,8 @@ func (suite *MultihopTestSuite) TestTimeoutOnClose() {
 
 			tc.malleate()
 
-			proofClosed, err := suite.Z().QueryChannelProof(suite.Z().Chain.LastHeader.GetHeight())
+			proofClosed, _, err := suite.Z().QueryChannelProof(suite.Z().Chain.LastHeader.GetHeight())
 			suite.Require().NoError(err)
-
-			proofHeight := suite.A().ProofHeight()
 
 			if tc.orderedChannel {
 				key = host.NextSequenceRecvKey(packet.GetDestPort(), packet.GetDestChannel())
@@ -153,7 +149,7 @@ func (suite *MultihopTestSuite) TestTimeoutOnClose() {
 				key = host.PacketReceiptKey(packet.GetDestPort(), packet.GetDestChannel(), packet.GetSequence())
 			}
 
-			proof, err := suite.Z().QueryMultihopProof(key, packetHeight)
+			proof, proofHeight, err := suite.Z().QueryMultihopProof(key, packetHeight)
 			suite.Require().NoError(err)
 
 			err = suite.A().Chain.App.GetIBCKeeper().ChannelKeeper.TimeoutOnClose(suite.A().Chain.GetContext(), chanCap, packet, proof, proofClosed, proofHeight, nextSeqRecv)


### PR DESCRIPTION
Return the proof height from multi-hop proof query.

Proof height is the consensus height of the counterparty chain used to verify the multi-hop proof since it may not have been queried using the latest consenus height.